### PR TITLE
Remove dependence on Q and return the same type of promise that was passed in

### DIFF
--- a/lib/last.js
+++ b/lib/last.js
@@ -1,28 +1,29 @@
 "use strict";
 
-var Q = require("q");
+var pending = { then: function () {} };
 
 module.exports = function (operation) {
     var latestPromise = null;
 
     return function () {
-        var deferred = Q.defer();
         var promiseForResult = operation.apply(this, arguments);
         latestPromise = promiseForResult;
 
-        promiseForResult.then(
+        return promiseForResult.then(
             function (value) {
                 if (latestPromise === promiseForResult) {
-                    deferred.resolve(value);
+                    return value;
+                } else {
+                    return pending;
                 }
             },
             function (reason) {
                 if (latestPromise === promiseForResult) {
-                    deferred.reject(reason);
+                    throw reason;
+                } else {
+                    return pending;
                 }
             }
         );
-
-        return deferred.promise;
     };
 };


### PR DESCRIPTION
I've wanted this module so many times.  Thanks so much for actually writing it.

I'd like to use this as part of the real-time rendering feature of regexplained.co.uk once I finish getting it to work with web-workers, but I'd rather use a more bare bones promise implementation (and I'm biased towards my own).

I also love the idea of making utilities that are promise library agnostic, so here goes.
